### PR TITLE
Fix package-lint errors

### DIFF
--- a/org-notify.el
+++ b/org-notify.el
@@ -3,7 +3,10 @@
 ;; Copyright (C) 2012-2021  Free Software Foundation, Inc.
 
 ;; Author: Peter Münster <pmrb@free.fr>
-;; Keywords: notification, todo-list, alarm, reminder, pop-up
+;; Keywords: notification, todo-list, alarm, reminder, pop-up, calendar
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "25.1"))
+;; URL: https://github.com/p-m/org-notify
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
This PR fixes some minor package-lint errors in an effort to get org-notify accepted into melpa